### PR TITLE
Add Mu.Callable($method) "coercer" in 6.e

### DIFF
--- a/src/core.e/Fixups.rakumod
+++ b/src/core.e/Fixups.rakumod
@@ -1,6 +1,19 @@
 # This file contains fixups to existing core classes by means of augmentation
 # for language level 6.e.
 
+augment class Mu {
+
+    # introducing .Callable($method)
+    method Callable(str $method) {
+        nqp::ifnull(
+          nqp::tryfindmethod(self,$method),
+          X::Method::NotFound.new(
+            :invocant(self), :typename(self.^name), :$method
+          ).Failure
+        )
+    }
+}
+
 augment class Any {
 
     # introducing snip


### PR DESCRIPTION
The idea being that *Raku* should provide a better HLL interface to obtain a Callable object for the given method name on the invocant.

    $ raku -e 'say Int.Callable("Str")(687, :subscript)'
    ₆₈₇

In place of the .^find_method logic, which is *not* Raku specific according to the documentation:

  https://docs.raku.org/type/Metamodel/DefiniteHOW#method_find_method